### PR TITLE
Fix read-after-eof panic

### DIFF
--- a/ext4/file.go
+++ b/ext4/file.go
@@ -91,6 +91,9 @@ func (f *File) Stat() (fs.FileInfo, error) {
 }
 
 func (f *File) Read(p []byte) (n int, err error) {
+	if f.buffer == nil {
+		return 0, io.EOF
+	}
 	if f.buffer.Len() == 0 {
 		f.currentBlock++
 		if f.currentBlock*f.blockSize >= f.Size() {


### PR DESCRIPTION
Fixed a panic that was caused when Read() was called after a previous Read() returned io.EOF